### PR TITLE
feat: add ternary conditional expressions

### DIFF
--- a/demos/ternary_demo.srv
+++ b/demos/ternary_demo.srv
@@ -1,0 +1,34 @@
+# Ternary Expression Demo
+# Syntax: value_if_true if condition else value_if_false
+
+x = 10
+result = "big" if x > 5 else "small"
+print result
+
+y = 3
+abs_val = y if y > 0 else 0 - y
+print abs_val
+
+a = 7
+b = 12
+max_val = a if a > b else b
+print max_val
+
+is_even = true if a % 2 == 0 else false
+print is_even
+
+age = 20
+print "adult" if age >= 18 else "minor"
+
+if x > 5
+    print "x is big (from if statement)"
+
+score = 85
+grade = "A" if score >= 90 else "B" if score >= 80 else "C"
+print grade
+
+function abs_value n
+    return n if n >= 0 else 0 - n
+
+print abs_value(5)
+print abs_value(0 - 3)

--- a/saurav.py
+++ b/saurav.py
@@ -467,6 +467,16 @@ class ContinueNode(ASTNode):
     def __repr__(self):
         return "ContinueNode()"
 
+
+class TernaryNode(ASTNode):
+    """Ternary conditional expression: true_expr if condition else false_expr"""
+    def __init__(self, condition, true_expr, false_expr):
+        self.condition = condition
+        self.true_expr = true_expr
+        self.false_expr = false_expr
+    def __repr__(self):
+        return f"TernaryNode({self.true_expr} if {self.condition} else {self.false_expr})"
+
 # Parser Class with Block Parsing and Full Control Flow
 class Parser:
     def __init__(self, tokens):
@@ -890,18 +900,27 @@ class Parser:
         return self.parse_pipe()
 
     def parse_pipe(self):
-        """Parse pipe expressions: expr (|> expr)*
-        
-        Left-associative. Lowest precedence operator.
-        The right side is parsed as a logical_or expression (which includes
-        function calls, lambdas, etc.)
-        """
-        left = self.parse_logical_or()
+        """Parse pipe expressions: expr (|> expr)*"""
+        left = self.parse_ternary()
         while self.peek()[0] == 'PIPE':
-            self.advance()  # consume |>
-            right = self.parse_logical_or()
+            self.advance()
+            right = self.parse_ternary()
             left = PipeNode(left, right)
         return left
+
+    def parse_ternary(self):
+        """Parse ternary conditional: true_expr if condition else false_expr"""
+        true_expr = self.parse_logical_or()
+        if self.peek()[0] == 'KEYWORD' and self.peek()[1] == 'if':
+            self.advance()
+            condition = self.parse_logical_or()
+            if self.peek()[0] == 'KEYWORD' and self.peek()[1] == 'else':
+                self.advance()
+                false_expr = self.parse_ternary()
+                return TernaryNode(condition, true_expr, false_expr)
+            else:
+                raise SyntaxError("Expected 'else' in ternary expression")
+        return true_expr
 
     def parse_logical_or(self):
         left = self.parse_logical_and()
@@ -1282,6 +1301,7 @@ class Interpreter:
             LambdaNode:       self._eval_lambda,
             PipeNode:         self._eval_pipe,
             EnumAccessNode:   self._eval_enum_access,
+            TernaryNode:      self._eval_ternary,
         }
 
     def _init_builtins(self):
@@ -2257,6 +2277,13 @@ class Interpreter:
         finally:
             self.variables = saved_env
         return result
+
+    def _eval_ternary(self, node):
+        condition = self.evaluate(node.condition)
+        if condition:
+            return self.evaluate(node.true_expr)
+        else:
+            return self.evaluate(node.false_expr)
 
     def _eval_pipe(self, node):
         """Evaluate a pipe expression: value |> function.

--- a/sauravcc.py
+++ b/sauravcc.py
@@ -288,6 +288,13 @@ class ForEachNode(ASTNode):
         self.body = body        # list of statements
 
 
+class TernaryNode(ASTNode):
+    def __init__(self, condition, true_expr, false_expr):
+        self.condition = condition
+        self.true_expr = true_expr
+        self.false_expr = false_expr
+
+
 # ============================================================
 # PARSER
 # ============================================================
@@ -611,7 +618,20 @@ class Parser:
     # atom -> NUMBER | STRING | BOOL | IDENT | '(' full_expression ')' | list | func_call
 
     def parse_full_expression(self):
-        return self.parse_logical_or()
+        return self.parse_ternary()
+
+    def parse_ternary(self):
+        true_expr = self.parse_logical_or()
+        if self.peek()[0] == 'KEYWORD' and self.peek()[1] == 'if':
+            self.advance()
+            condition = self.parse_logical_or()
+            if self.peek()[0] == 'KEYWORD' and self.peek()[1] == 'else':
+                self.advance()
+                false_expr = self.parse_ternary()
+                return TernaryNode(condition, true_expr, false_expr)
+            else:
+                raise SyntaxError("Expected 'else' in ternary expression")
+        return true_expr
 
     def parse_logical_or(self):
         left = self.parse_logical_and()
@@ -1851,6 +1871,12 @@ class CCodeGenerator:
 
         elif isinstance(expr, FStringNode):
             return self.compile_fstring(expr)
+
+        elif isinstance(expr, TernaryNode):
+            cond_c = self.compile_expression(expr.condition)
+            true_c = self.compile_expression(expr.true_expr)
+            false_c = self.compile_expression(expr.false_expr)
+            return f"(({cond_c}) ? ({true_c}) : ({false_c}))"
 
         elif isinstance(expr, MethodCallNode):
             obj_c = self.compile_expression(expr.obj)


### PR DESCRIPTION
Adds Python-style ternary conditional expressions to sauravcode.

Syntax: value_if_true if condition else value_if_false

Changes:
- saurav.py: TernaryNode AST class, parse_ternary() parser, _eval_ternary() interpreter
- sauravcc.py: TernaryNode class, parse_ternary(), C ternary operator compilation  
- demos/ternary_demo.srv: Demo with examples including nested ternaries

Design: sits between pipe and logical_or precedence, right-associative for chaining.
All existing tests pass.
