### PR TITLE
perf: eliminate per-call import and copy in _eval_identifier closure capture

### DIFF
--- a/saurav.py
+++ b/saurav.py
@@ -3928,10 +3928,12 @@ class Interpreter:
         elif node.name in self.functions:
             if DEBUG:
                 debug(f"Identifier '{node.name}' is a function name")
-            # Return the actual FunctionNode with captured closure scope so
-            # it can be used as a first-class value at any call depth.
-            import copy
-            func_node = copy.copy(self.functions[node.name])
+            # Return a lightweight FunctionNode copy with captured closure
+            # scope so it can be used as a first-class value at any call
+            # depth.  Avoids per-call ``import copy`` and ``copy.copy()``
+            # overhead by constructing a new node directly.
+            orig = self.functions[node.name]
+            func_node = FunctionNode(orig.name, orig.params, orig.body)
             func_node.closure_scope = dict(self.variables)
             return func_node
         elif node.name in self.builtins:


### PR DESCRIPTION
## Problem

When \_eval_identifier\ returns a function reference as a first-class value (for higher-order functions, closures, etc.), it previously executed:

\\\python
import copy
func_node = copy.copy(self.functions[node.name])
func_node.closure_scope = dict(self.variables)
\\\

Two performance issues:
1. **\import copy\ on every call** — import machinery overhead on each invocation
2. **\copy.copy()\** — traverses object's \__dict__\ via copyreg, heavier than needed

## Fix

Direct FunctionNode construction — faster and more explicit:

\\\python
orig = self.functions[node.name]
func_node = FunctionNode(orig.name, orig.params, orig.body)
func_node.closure_scope = dict(self.variables)
\\\

## Impact

Every function-as-value reference (higher-order functions, closures, map/filter/reduce callbacks) triggers this path. Eliminates unnecessary overhead per reference.

## Testing

All existing tests pass (2 pre-existing failures unrelated to this change).