### PR TITLE
security: fix symlink-based path traversal escape in file I/O sandbox

### DIFF
--- a/saurav.py
+++ b/saurav.py
@@ -4037,15 +4037,20 @@ class Interpreter:
 
         # When running from a file, enforce path traversal protection
         if self._source_dir is not None:
-            allowed_root = os.path.abspath(self._source_dir)
+            # Use realpath to resolve symlinks — abspath alone can be
+            # bypassed via symlink chains that point outside the sandbox.
+            allowed_root = os.path.realpath(self._source_dir)
 
             if os.path.isabs(path):
-                full_path = os.path.abspath(path)
+                full_path = os.path.realpath(path)
             else:
-                full_path = os.path.abspath(os.path.join(allowed_root, path))
+                full_path = os.path.realpath(os.path.join(allowed_root, path))
 
-            # Path traversal check — must resolve within allowed root
-            if not full_path.startswith(allowed_root + os.sep) and full_path != allowed_root:
+            # Path traversal check — must resolve within allowed root.
+            # Use os.path.normcase for case-insensitive comparison on Windows.
+            norm_root = os.path.normcase(allowed_root)
+            norm_full = os.path.normcase(full_path)
+            if not norm_full.startswith(norm_root + os.sep) and norm_full != norm_root:
                 raise RuntimeError(
                     f"{func_name}: path traversal outside project directory "
                     f"is not allowed ('{path}' resolves outside '{allowed_root}')"

--- a/tests/test_file_io_sandbox.py
+++ b/tests/test_file_io_sandbox.py
@@ -232,6 +232,27 @@ class TestInteractiveModeNoRestriction:
         )
         assert output.strip() == "repl data"
 
+    def test_symlink_traversal_blocked(self, tmp_path):
+        """Symlinks pointing outside the sandbox must be rejected."""
+        sandbox = tmp_path / "sandbox"
+        sandbox.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        secret = outside / "secret.txt"
+        secret.write_text("top secret")
+
+        link = sandbox / "escape"
+        try:
+            link.symlink_to(outside)
+        except OSError:
+            pytest.skip("symlinks not supported on this platform")
+
+        with pytest.raises(RuntimeError, match="path traversal"):
+            run_code_sandboxed(
+                'print (read_file "escape/secret.txt")',
+                str(sandbox),
+            )
+
     def test_write_absolute_path_in_repl(self, tmp_path):
         target = tmp_path / "output.txt"
         abs_path = str(target).replace("\\", "/")


### PR DESCRIPTION
## Security Fix

The _validate_file_path method used os.path.abspath which does not resolve symlinks. An attacker could create a symlink inside the project directory pointing outside the sandbox, then read/write arbitrary files through it.

### Changes
- saurav.py: Replace os.path.abspath with os.path.realpath to resolve symlinks
- saurav.py: Add os.path.normcase for case-insensitive path comparison on Windows
- tests/test_file_io_sandbox.py: Add test_symlink_traversal_blocked
