### PR TITLE
fix(sauravmigrate): emit while-loop for range(start, stop, step)

### DIFF
--- a/sauravmigrate.py
+++ b/sauravmigrate.py
@@ -214,6 +214,75 @@ class PythonToSrv(ast.NodeVisitor):
 
     # ── For ──
 
+    @staticmethod
+    def _literal_int_value(node):
+        """Return the int value of a literal AST expression, or None.
+
+        Handles plain `ast.Constant` integer literals and `ast.UnaryOp(USub, ...)`
+        wrapping a constant (i.e. negative literals like ``-1``), which is how
+        the AST represents them.
+        """
+        if isinstance(node, ast.Constant) and isinstance(node.value, int) and not isinstance(node.value, bool):
+            return node.value
+        if (isinstance(node, ast.UnaryOp)
+                and isinstance(node.op, ast.USub)
+                and isinstance(node.operand, ast.Constant)
+                and isinstance(node.operand.value, int)
+                and not isinstance(node.operand.value, bool)):
+            return -node.operand.value
+        return None
+
+    def _emit_range_with_step(self, node, target, args):
+        """Migrate ``for target in range(start, stop, step):`` as a while-loop.
+
+        sauravcode's native ``for`` loop only takes start/stop, so a literal
+        step is emitted as the equivalent ``target = start; while ...``
+        sequence with a trailing ``target = target + step`` to advance the
+        induction variable. A non-literal step would need a runtime sign
+        decision sauravcode can't express cleanly, so it gets a hard TODO
+        comment and the body is dropped — failing loudly is safer than the
+        previous behaviour, which silently emitted a 2-arg ``for`` that ran
+        the wrong number of iterations or in the wrong direction.
+        """
+        step_value = self._literal_int_value(args[2])
+        start_expr = self._expr(args[0])
+        stop_expr = self._expr(args[1])
+        step_expr = self._expr(args[2])
+
+        if step_value is None:
+            self.warnings.add(
+                node.lineno,
+                "range() with non-literal step requires manual migration",
+            )
+            self.emit(
+                f"# TODO MANUAL MIGRATION: range({start_expr}, {stop_expr}, {step_expr}) "
+                f"— rewrite as a while-loop matching the runtime sign of step"
+            )
+            return
+
+        if step_value == 0:
+            self.warnings.add(
+                node.lineno,
+                "range() with step=0 is a ValueError in Python; skipping body",
+            )
+            self.emit(
+                f"# TODO MANUAL MIGRATION: range({start_expr}, {stop_expr}, 0) "
+                f"would raise ValueError in Python"
+            )
+            return
+
+        comparator = "<" if step_value > 0 else ">"
+        self.emit(f"{target} = {start_expr}")
+        self.emit(f"while {target} {comparator} {stop_expr}")
+        self.indent += 1
+        self._emit_body(node.body)
+        self.emit(f"{target} = {target} + {step_expr}")
+        self.indent -= 1
+        if node.orelse:
+            self.warnings.add(
+                node.lineno, "for/else not supported, else branch skipped",
+            )
+
     def visit_For(self, node):
         target = self._expr(node.target)
 
@@ -227,8 +296,13 @@ class PythonToSrv(ast.NodeVisitor):
             elif len(args) == 2:
                 self.emit(f"for {target} {self._expr(args[0])} {self._expr(args[1])}")
             elif len(args) == 3:
-                self.warnings.add(node.lineno, "range() step argument not supported, using 2-arg form")
-                self.emit(f"for {target} {self._expr(args[0])} {self._expr(args[1])}")
+                # The 3-arg form needs a fully custom emission path because the
+                # sauravcode for-loop has no step argument. _emit_range_with_step
+                # owns the entire block (header, body, induction step) and
+                # returns without falling through to the shared body-emission
+                # block below.
+                self._emit_range_with_step(node, target, args)
+                return
             else:
                 self.emit(f"for {target} in {self._expr(node.iter)}")
         else:

--- a/sauravmigrate.py
+++ b/sauravmigrate.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""sauravmigrate.py — Migrate Python scripts to sauravcode (.srv).
+"""sauravmigrate.py, Migrate Python scripts to sauravcode (.srv).
 
 Converts simple Python code into idiomatic sauravcode by parsing
 the Python AST and emitting equivalent .srv syntax.
@@ -28,7 +28,7 @@ Supported Python constructs:
     - List comprehensions (simple cases)
 
 Unsupported (skipped with warnings):
-    - Classes (partial — no inheritance)
+    - Classes (partial, no inheritance)
     - Decorators
     - With statements
     - Async/await
@@ -116,7 +116,7 @@ class PythonToSrv(ast.NodeVisitor):
         self.emit(f"{target} = {target} {op} {value}")
 
     def visit_AnnAssign(self, node):
-        # Type annotations — ignore annotation, keep assignment
+        # Type annotations, ignore annotation, keep assignment
         if node.value is not None:
             target = self._expr(node.target)
             value = self._expr(node.value)
@@ -125,7 +125,7 @@ class PythonToSrv(ast.NodeVisitor):
     # ── Expressions as statements ──
 
     def visit_Expr(self, node):
-        # Check for standalone string (docstring) — emit as comment
+        # Check for standalone string (docstring), emit as comment
         if isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
             for line in node.value.value.strip().split("\n"):
                 self.emit(f"# {line}")
@@ -240,7 +240,7 @@ class PythonToSrv(ast.NodeVisitor):
         sequence with a trailing ``target = target + step`` to advance the
         induction variable. A non-literal step would need a runtime sign
         decision sauravcode can't express cleanly, so it gets a hard TODO
-        comment and the body is dropped — failing loudly is safer than the
+        comment and the body is dropped, failing loudly is safer than the
         previous behaviour, which silently emitted a 2-arg ``for`` that ran
         the wrong number of iterations or in the wrong direction.
         """
@@ -256,7 +256,7 @@ class PythonToSrv(ast.NodeVisitor):
             )
             self.emit(
                 f"# TODO MANUAL MIGRATION: range({start_expr}, {stop_expr}, {step_expr}) "
-                f"— rewrite as a while-loop matching the runtime sign of step"
+                f", rewrite as a while-loop matching the runtime sign of step"
             )
             return
 
@@ -380,16 +380,16 @@ class PythonToSrv(ast.NodeVisitor):
 
     def visit_Import(self, node):
         names = ", ".join(a.name for a in node.names)
-        self.warnings.add(node.lineno, f"import {names} — no equivalent, skipped")
+        self.warnings.add(node.lineno, f"import {names}, no equivalent, skipped")
 
     def visit_ImportFrom(self, node):
         names = ", ".join(a.name for a in node.names)
-        self.warnings.add(node.lineno, f"from {node.module} import {names} — skipped")
+        self.warnings.add(node.lineno, f"from {node.module} import {names}, skipped")
 
     # ── Class (partial) ──
 
     def visit_ClassDef(self, node):
-        self.warnings.add(node.lineno, f"class '{node.name}' — classes have limited support")
+        self.warnings.add(node.lineno, f"class '{node.name}', classes have limited support")
         self.emit(f"class {node.name}")
         self.indent += 1
         self._emit_body(node.body)
@@ -470,7 +470,7 @@ class PythonToSrv(ast.NodeVisitor):
         if isinstance(node, ast.JoinedStr):
             return self._fstring(node)
         if isinstance(node, ast.IfExp):
-            # Ternary — sauravcode doesn't have ternary, use inline
+            # Ternary, sauravcode doesn't have ternary, use inline
             # We'll emit it as a comment with a warning
             body = self._expr(node.body)
             test = self._expr(node.test)
@@ -616,7 +616,7 @@ class PythonToSrv(ast.NodeVisitor):
                 return f"[{elt} for {target} in {iter_expr}]"
             cond = self._expr(gen.ifs[0])
             return f"[{elt} for {target} in {iter_expr} if {cond}]"
-        # Nested — warn and do best effort
+        # Nested, warn and do best effort
         return f"/* complex comprehension */"
 
 

--- a/tests/test_sauravmigrate.py
+++ b/tests/test_sauravmigrate.py
@@ -77,6 +77,49 @@ class TestControlFlow:
         result = migrate_source("for i in range(1, 5):\n    print(i)")
         assert "for i 1 5" in result
 
+    def test_for_range_positive_step_emits_while_loop(self):
+        # Regression for #125: range(start, stop, step) with a positive
+        # literal step used to silently drop the step and emit a 2-arg
+        # `for` that iterated the wrong number of times. The migrator now
+        # emits an equivalent while-loop so iteration count matches Python.
+        result = migrate_source("for i in range(0, 10, 2):\n    print(i)")
+        # No "for i 0 10" — that was the buggy output.
+        assert "for i 0 10" not in result
+        # While-loop equivalent must include the start assignment, the
+        # `<` comparator (positive step), and the in-loop increment.
+        assert "i = 0" in result
+        assert "while i < 10" in result
+        assert "i = i + 2" in result
+
+    def test_for_range_negative_step_uses_greater_than(self):
+        # Negative step (countdown) needs the comparator flipped to `>`,
+        # otherwise the loop would iterate zero times or the wrong way.
+        # The migrator's expression emitter renders -1 as the binary
+        # form `0 - 1`, so checking "i = i + 0 - 1" is the literal output;
+        # functionally equivalent to `i = i + -1`.
+        result = migrate_source("for i in range(10, 0, -1):\n    print(i)")
+        assert "i = 10" in result
+        assert "while i > 0" in result
+        assert "i = i + 0 - 1" in result
+
+    def test_for_range_non_literal_step_emits_todo(self):
+        # When the step is a runtime expression we can't decide the
+        # comparator at migration time, so the migrator must fail loudly
+        # with a manual-migration TODO rather than silently produce a
+        # 2-arg `for` that runs forward.
+        src = "step = -1\nfor i in range(10, 0, step):\n    print(i)"
+        result = migrate_source(src)
+        assert "TODO MANUAL MIGRATION" in result
+        # No buggy 2-arg fallback should leak through.
+        assert "for i 10 0" not in result
+
+    def test_for_range_zero_step_emits_todo(self):
+        # range(_, _, 0) raises ValueError in Python at call time. The
+        # migrator should not silently emit a runnable loop for it.
+        result = migrate_source("for i in range(0, 10, 0):\n    print(i)")
+        assert "TODO MANUAL MIGRATION" in result
+        assert "while i" not in result
+
     def test_for_each(self):
         result = migrate_source("for x in items:\n    print(x)")
         assert "for x in items" in result

--- a/tests/test_sauravmigrate.py
+++ b/tests/test_sauravmigrate.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Tests for sauravmigrate.py — Python-to-sauravcode transpiler."""
+"""Tests for sauravmigrate.py, Python-to-sauravcode transpiler."""
 
 import sys
 import os
@@ -83,7 +83,7 @@ class TestControlFlow:
         # `for` that iterated the wrong number of times. The migrator now
         # emits an equivalent while-loop so iteration count matches Python.
         result = migrate_source("for i in range(0, 10, 2):\n    print(i)")
-        # No "for i 0 10" — that was the buggy output.
+        # No "for i 0 10", that was the buggy output.
         assert "for i 0 10" not in result
         # While-loop equivalent must include the start assignment, the
         # `<` comparator (positive step), and the in-loop increment.


### PR DESCRIPTION
## Summary

Closes #125.

\`sauravmigrate.py\` silently dropped the \`step\` argument when
migrating Python \`for i in range(start, stop, step):\` and emitted a
2-arg \`for i start stop\`, which sauravcode iterates as a forward
range with implicit step=1. Only a migration *warning comment* was
recorded, the actual generated loop ran the wrong number of
iterations or in the wrong direction.

Concrete failure modes the previous behaviour produced:

- \`range(10, 0, -1)\` → \`for i 10 0\` ran zero iterations or
  iterated forward, instead of counting 10..1.
- \`range(0, 10, 2)\` → \`for i 0 10\` ran 10 iterations with values
  0..9, instead of 5 iterations with 0, 2, 4, 6, 8.

## Fix

The 3-arg form now emits a while-loop equivalent (Option A from the
issue body). Iteration count and direction match the original Python:

\`\`\`
for i in range(0, 10, 2):           i = 0
    print(i)             becomes    while i < 10
                                        print i
                                        i = i + 2
\`\`\`

- Positive literal step uses comparator \`<\`.
- Negative literal step (e.g. \`range(10, 0, -1)\`) flips to \`>\` so
  countdown loops migrate correctly.
- A new helper \`_literal_int_value\` extracts the literal step,
  handling both \`ast.Constant(N)\` and \`ast.UnaryOp(USub, ...)\`
  (the AST shape Python uses for \`-1\`).
- Step \`0\` (a \`ValueError\` in Python at call time) and non-literal
  step expressions get a hard \`TODO MANUAL MIGRATION\` comment with
  no fallback \`for\` emitted. Failing loudly is much safer than the
  old silent-success behaviour for cases sauravcode can't faithfully
  represent at compile time.

## Test plan

Four regression tests added in \`tests/test_sauravmigrate.py\`:

- [x] positive literal step → while-loop with \`<\` and increment
- [x] negative literal step → while-loop with \`>\`
- [x] non-literal step → \`TODO MANUAL MIGRATION\`, no \`for i …\`
      fallback emitted
- [x] step=0 → \`TODO MANUAL MIGRATION\`, no while-loop emitted

Verified each new test fails when only \`sauravmigrate.py\` is
reverted, confirming they exercise the new behaviour.

\`pytest tests/test_sauravmigrate.py\`, 41 passed.

(There's a separate pre-existing failure in
\`tests/test_hash_encoding.py::TestMd5::test_number_coerced_to_string\`
that reproduces on \`main\` without these changes; unrelated to this
PR.)